### PR TITLE
chore(build-tools): remove broken dev:experimental script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "start": "node ./dist/server/server.js",
     "build:web-builder": "esbuild ./src/modules/webBuilder/app/index.tsx --outdir=./dist/web-builder --format=iife --sourcemap --source-root=../src --bundle",
     "scripts:compile": "ts-node ./scripts/build-components.ts",
-    "dev": "yarn nodemon --inspect ./dist/server/server.js --ignore ./plugins --ignore ./uploads",
-    "dev:experimental": "yarn nodemon --inspect ./dist/server/server.js --ignore ./plugins --ignore ./uploads"
+    "dev": "yarn nodemon --inspect ./dist/server/server.js --ignore ./plugins --ignore ./uploads"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
It seems using the nodemon + ts-node combo does not perfrorm as
good as the current setup.
Further more the nodemon + ts-node pair is hard work with because
  - resources are not available and the server returns 404, missing
  	index.css and index.js
  - unable to configure the server to run with esbuild compiler
  - does not restart nor recompile the files on change